### PR TITLE
Rsc1 api constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,15 @@ ably.channels.foo.presence()
 
 ### Credentials
 
-You can provide either a `key` string or `app_id` + `key_id` + `key_value`
-combination.
+You can provide either a `key`, a `token` or, if you need more flexibility,
+with an `Option` object.
 
 ```python
 ably = AblyRest("key-string")
 ```
+
 or
 
 ```python
-ably = AblyRest(app_id="app-id", key_id="key-id", key_value="key-value")
+ably = AblyRest(token="app-token")
 ```

--- a/ably/rest/rest.py
+++ b/ably/rest/rest.py
@@ -26,7 +26,7 @@ class AblyRest(object):
           - `key`: a valid key string
 
           **Or**
-          - `token`: Your Ably key id
+          - `token`: a valid token string
 
           **Optional Parameters**
           - `client_id`: Undocumented
@@ -52,9 +52,8 @@ class AblyRest(object):
                 options.auth_token = token
         elif options is None or not (options.auth_callback or options.auth_url or
                                      options.key_value or options.auth_token):
-            # TODO: what's the pattern for error codes?
-            raise AblyException("No authentication information provided",
-                                0, 0)
+            raise AblyException("Must include valid auth parameters",
+                                400, 40000)
 
         self.__client_id = options.client_id
 

--- a/ably/types/authoptions.py
+++ b/ably/types/authoptions.py
@@ -8,29 +8,27 @@ from ably.util.exceptions import AblyException
 class AuthOptions(object):
     def __init__(self, auth_callback=None, auth_url=None, auth_token=None,
                  auth_headers=None, auth_params=None, key_id=None, key_value=None,
-                 query_time=False):
+                 key=None, query_time=False):
         self.__auth_callback = auth_callback
         self.__auth_url = auth_url
         self.__auth_token = auth_token
         self.__auth_headers = auth_headers
         self.__auth_params = auth_params
-        self.__key_id = key_id
-        self.__key_value = key_value
+        if key is not None:
+            self.__key_id, self.__key_value = self.parse_key(key)
+        else:
+            self.__key_id = key_id
+            self.__key_value = key_value
         self.__query_time = query_time
 
-    @classmethod
-    def with_key(cls, key, **kwargs):
-        kwargs = kwargs or {}
-
-        key_components = key.split(':')
-
-        if len(key_components) != 2:
-            raise AblyException("invalid key parameter", 401, 40101)
-
-        kwargs['key_id'] = key_components[0]
-        kwargs['key_value'] = key_components[1]
-
-        return cls(**kwargs)
+    def parse_key(self, key):
+        try:
+            key_id, key_value = key.split(':')
+            return key_id, key_value
+        except ValueError:
+            raise AblyException("key of not len 2 parameters: {0}"
+                                .format(key.split(':')),
+                                401, 40101)
 
     def merge(self, other):
         if self.__auth_callback is None:

--- a/ably/types/options.py
+++ b/ably/types/options.py
@@ -23,22 +23,6 @@ class Options(AuthOptions):
         self.__queue_messages = queue_messages
         self.__recover = recover
 
-    @classmethod
-    def with_key(cls, key, **kwargs):
-        kwargs = kwargs or {}
-
-        key_components = key.split(':')
-
-        if len(key_components) != 2:
-            raise AblyException("key of not len 2 parameters: {0}"
-                                .format(key.split(':')),
-                                401, 40101)
-
-        kwargs['key_id'] = key_components[0]
-        kwargs['key_value'] = key_components[1]
-
-        return cls(**kwargs)
-
     @property
     def client_id(self):
         return self.__client_id

--- a/test/ably/restappstats_test.py
+++ b/test/ably/restappstats_test.py
@@ -27,11 +27,11 @@ class TestRestAppStats(unittest.TestCase):
     def setUpClass(cls):
         log.debug("KEY class: "+test_vars["keys"][0]["key_str"])
         log.debug("TLS: "+str(test_vars["tls"]))
-        cls.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            options=Options(host=test_vars["host"],
+                                            port=test_vars["port"],
+                                            tls_port=test_vars["tls_port"],
+                                            tls=test_vars["tls"]))
         time_from_service = cls.ably.time()
         cls.time_offset = time_from_service / 1000.0 - time.time()
 

--- a/test/ably/restauth_test.py
+++ b/test/ably/restauth_test.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import logging
 import unittest
-import os 
 
 from ably import AblyRest
 from ably import Auth
@@ -16,24 +15,19 @@ test_vars = RestSetup.get_test_vars()
 
 log = logging.getLogger(__name__)
 
+
 class TestAuth(unittest.TestCase):
+
     def test_auth_init_key_only(self):
-        
-        ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"]))
-        print(test_vars["keys"][0]["key_str"])
-        log.debug("Method: %s" % ably.auth.auth_method)
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"])
         self.assertEqual(Auth.Method.BASIC, ably.auth.auth_method,
-                msg="Unexpected Auth method mismatch")
+                         msg="Unexpected Auth method mismatch")
 
     def test_auth_init_token_only(self):
-        options = {
-            "auth_token": "this_is_not_really_a_token",
-        }
-
-        ably = AblyRest(Options(auth_token="this_is_not_really_a_token"))
+        ably = AblyRest(token="this_is_not_really_a_token")
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
-                msg="Unexpected Auth method mismatch")
+                         msg="Unexpected Auth method mismatch")
 
     def test_auth_init_with_token_callback(self):
         callback_called = []
@@ -50,7 +44,7 @@ class TestAuth(unittest.TestCase):
         options.tls = test_vars["tls"]
         options.auth_callback = token_callback
 
-        ably = AblyRest(options)
+        ably = AblyRest(options=options)
 
         try:
             ably.stats(None)
@@ -62,10 +56,10 @@ class TestAuth(unittest.TestCase):
                 msg="Unexpected Auth method mismatch")
         
     def test_auth_init_with_key_and_client_id(self):
-        options = Options.with_key(test_vars["keys"][0]["key_str"])
+        options = Options(key=test_vars["keys"][0]["key_str"])
         options.client_id = "testClientId"
 
-        ably = AblyRest(options)
+        ably = AblyRest(options=options)
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
                 msg="Unexpected Auth method mismatch")
@@ -74,7 +68,8 @@ class TestAuth(unittest.TestCase):
         options = Options(host=test_vars["host"], port=test_vars["port"],
             tls_port=test_vars["tls_port"], tls=test_vars["tls"])
 
-        ably = AblyRest(options)
+        ably = AblyRest(token="this_is_not_really_a_token",
+                        options=options)
 
         self.assertEqual(Auth.Method.TOKEN, ably.auth.auth_method,
                 msg="Unexpected Auth method mismatch")

--- a/test/ably/restcapability_test.py
+++ b/test/ably/restcapability_test.py
@@ -21,11 +21,11 @@ test_vars = RestSetup.get_test_vars()
 class TestRestCapability(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            options=Options(host=test_vars["host"],
+                                            port=test_vars["port"],
+                                            tls_port=test_vars["tls_port"],
+                                            tls=test_vars["tls"]))
 
     @property
     def ably(self):

--- a/test/ably/restchannelhistory_test.py
+++ b/test/ably/restchannelhistory_test.py
@@ -23,11 +23,11 @@ log = logging.getLogger(__name__)
 class TestRestChannelHistory(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            options=Options(host=test_vars["host"],
+                                            port=test_vars["port"],
+                                            tls_port=test_vars["tls_port"],
+                                            tls=test_vars["tls"]))
         cls.time_offset = cls.ably.time() - int(time.time())
 
     @property

--- a/test/ably/restchannelpublish_test.py
+++ b/test/ably/restchannelpublish_test.py
@@ -22,19 +22,19 @@ log = logging.getLogger(__name__)
 class TestRestChannelPublish(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"],
-                use_text_protocol=True))
+        cls.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                            options=Options(host=test_vars["host"],
+                                            port=test_vars["port"],
+                                            tls_port=test_vars["tls_port"],
+                                            tls=test_vars["tls"],
+                                            use_text_protocol=True))
 
-        cls.ably_binary = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"],
-                use_text_protocol=False))
+        cls.ably_binary = AblyRest(key=test_vars["keys"][0]["key_str"],
+                                   options=Options(host=test_vars["host"],
+                                                   port=test_vars["port"],
+                                                   tls_port=test_vars["tls_port"],
+                                                   tls=test_vars["tls"],
+                                                   use_text_protocol=False))
 
     def test_publish_various_datatypes_text(self):
         publish0 = TestRestChannelPublish.ably.channels["persisted:publish0"]

--- a/test/ably/restcrypto_test.py
+++ b/test/ably/restcrypto_test.py
@@ -22,14 +22,14 @@ log = logging.getLogger(__name__)
 class TestRestCrypto(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        options = Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"],
-                use_text_protocol=True)
-        cls.ably = AblyRest(options)
-        cls.ably2 = AblyRest(options)
+        options = Options(key=test_vars["keys"][0]["key_str"],
+                          host=test_vars["host"],
+                          port=test_vars["port"],
+                          tls_port=test_vars["tls_port"],
+                          tls=test_vars["tls"],
+                          use_text_protocol=True)
+        cls.ably = AblyRest(options=options)
+        cls.ably2 = AblyRest(options=options)
 
     def test_cbc_channel_cipher(self):
         key = six.b(

--- a/test/ably/restinit_test.py
+++ b/test/ably/restinit_test.py
@@ -14,36 +14,68 @@ test_vars = RestSetup.get_test_vars()
 
 class TestRestInit(unittest.TestCase):
     def test_key_only(self):
-        AblyRest(Options.with_key(test_vars["keys"][0]["key_str"]))
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"])
+        self.assertEqual(ably.options.key_id, test_vars["keys"][0]["key_id"],
+                         "Key id does not match")
+        self.assertEqual(ably.options.key_value, test_vars["keys"][0]["key_value"],
+                         "Key value does not match")
 
     def test_key_in_options(self):
-        AblyRest(Options.with_key(test_vars["keys"][0]["key_str"]))
+        ably = AblyRest(options=Options(key=test_vars["keys"][0]["key_str"]))
+        self.assertEqual(ably.options.key_id, test_vars["keys"][0]["key_id"],
+                         "Key id does not match")
+        self.assertEqual(ably.options.key_value, test_vars["keys"][0]["key_value"],
+                         "Key value does not match")
+
+    def test_token_in_options(self):
+        ably = AblyRest(options=Options(auth_token='foo'))
+        self.assertEqual(ably.options.auth_token, 'foo',
+                         "Token not set at options")
+
+    def test_with_token(self):
+        ably = AblyRest(token='foo')
+        self.assertEqual(ably.options.auth_token, 'foo',
+                         "Token not set at options")
+
+    def test_with_options_token_callback(self):
+        def token_callback(**params):
+            return "this_is_not_really_a_token_request"
+        AblyRest(options=Options(auth_callback=token_callback))
+
+    def test_with_options_auth_url(self):
+        AblyRest(options=Options(auth_url='not_really_an_url'))
 
     def test_specified_host(self):
-        ably = AblyRest(Options(host="some.other.host"))
-        self.assertEqual("some.other.host", ably.options.host, 
-                msg="Unexpected host mismatch")
+        ably = AblyRest(token='foo', options=Options(host="some.other.host"))
+        self.assertEqual("some.other.host", ably.options.host,
+                         msg="Unexpected host mismatch")
 
     def test_specified_port(self):
-        ably = AblyRest(Options(port=9998, tls_port=9999))
+        ably = AblyRest(token='foo', options=Options(port=9998, tls_port=9999))
         self.assertEqual(9999, Defaults.get_port(ably.options),
-                msg="Unexpected port mismatch. Expected: 9999. Actual: %d" % ably.options.tls_port)
+                         msg="Unexpected port mismatch. Expected: 9999. Actual: %d" %
+                         ably.options.tls_port)
 
     def test_tls_defaults_to_true(self):
-        ably = AblyRest()
+        ably = AblyRest(token='foo')
         self.assertTrue(ably.options.tls,
-                msg="Expected encryption to default to true")
+                        msg="Expected encryption to default to true")
         self.assertEqual(Defaults.tls_port, Defaults.get_port(ably.options),
-                msg="Unexpected port mismatch")
+                         msg="Unexpected port mismatch")
 
     def test_tls_can_be_disabled(self):
-        ably = AblyRest(Options(tls=False))
+        ably = AblyRest(token='foo', options=Options(tls=False))
         self.assertFalse(ably.options.tls,
-                msg="Expected encryption to be False")
+                         msg="Expected encryption to be False")
         self.assertEqual(Defaults.port, Defaults.get_port(ably.options),
-                msg="Unexpected port mismatch")
+                         msg="Unexpected port mismatch")
+
+    def test_with_no_params(self):
+        self.assertRaises(AblyException, AblyRest)
+
+    def test_with_no_auth_params(self):
+        self.assertRaises(AblyException, AblyRest, options=Options(port=111))
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/test/ably/restsetup.py
+++ b/test/ably/restsetup.py
@@ -35,10 +35,11 @@ else:
     tls_port = 8081
 
 
-ably = AblyRest(Options(host=host,
-        port=port,
-        tls_port=tls_port,
-        tls=tls))
+ably = AblyRest(token='not_a_real_token',
+                options=Options(host=host,
+                                port=port,
+                                tls_port=tls_port,
+                                tls=tls))
 
 
 class RestSetup:
@@ -77,12 +78,12 @@ class RestSetup:
     @staticmethod
     def clear_test_vars():
         test_vars = RestSetup.__test_vars
-        options = Options.with_key(test_vars["keys"][0]["key_str"])
+        options = Options(key=test_vars["keys"][0]["key_str"])
         options.host = test_vars["host"]
         options.port = test_vars["port"]
         options.tls_port = test_vars["tls_port"]
         options.tls = test_vars["tls"]
-        ably = AblyRest(options)
+        ably = AblyRest(options=options)
 
         headers = HttpUtils.default_get_headers()
         ably.http.delete('/apps/' + test_vars['app_id'], headers)

--- a/test/ably/resttime_test.py
+++ b/test/ably/resttime_test.py
@@ -14,11 +14,11 @@ test_vars = RestSetup.get_test_vars()
 
 class TestRestTime(unittest.TestCase):
     def test_time_accuracy(self):
-        ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                        options=Options(host=test_vars["host"],
+                                        port=test_vars["port"],
+                                        tls_port=test_vars["tls_port"],
+                                        tls=test_vars["tls"]))
 
         reported_time = ably.time()
         actual_time = time.time() * 1000.0
@@ -27,18 +27,18 @@ class TestRestTime(unittest.TestCase):
                 msg="Time is not within 2 seconds")
 
     def test_time_without_key_or_token(self):
-        ably = AblyRest(Options(host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        ably = AblyRest(token='foo',
+                        options=Options(host=test_vars["host"],
+                                        port=test_vars["port"],
+                                        tls_port=test_vars["tls_port"],
+                                        tls=test_vars["tls"]))
 
         ably.time()
-    
+
     def test_time_fails_without_valid_host(self):
-        ably = AblyRest(Options(host="this.host.does.not.exist",
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"]))
+        ably = AblyRest(token='foo',
+                        options=Options(host="this.host.does.not.exist",
+                                        port=test_vars["port"],
+                                        tls_port=test_vars["tls_port"]))
 
         self.assertRaises(AblyException, ably.time)
-
-

--- a/test/ably/resttoken_test.py
+++ b/test/ably/resttoken_test.py
@@ -25,11 +25,11 @@ class TestRestToken(unittest.TestCase):
     def setUp(self):
         capability = {"*":["*"]}
         self.permit_all = six.text_type(Capability(capability))
-        self.ably = AblyRest(Options.with_key(test_vars["keys"][0]["key_str"],
-                host=test_vars["host"],
-                port=test_vars["port"],
-                tls_port=test_vars["tls_port"],
-                tls=test_vars["tls"]))
+        self.ably = AblyRest(key=test_vars["keys"][0]["key_str"],
+                             options=Options(host=test_vars["host"],
+                                             port=test_vars["port"],
+                                             tls_port=test_vars["tls_port"],
+                                             tls=test_vars["tls"]))
 
     def test_request_token_null_params(self):
         pre_time = self.server_time()


### PR DESCRIPTION
(RSC1) The constructor accepts either an API key, a token string, or a set of ClientOptions. An exception is raised if invalid arguments are provided such as no API key, token and no means to create a token
